### PR TITLE
Badwords: transsexual → transgender

### DIFF
--- a/badwords.csv
+++ b/badwords.csv
@@ -192,7 +192,7 @@ en,snatch,vulgar name for vagina (also to grab without permission),2
 en,strap-on/strap-ons,sex toy,2
 en,titties,breasts,1
 en,tit/tits,breasts (also a bird species) ,1
-en,tranny/trannies,vulgar term for transsexual,2
+en,tranny/trannies,vulgar term for transgender person,2
 en,turd/turds,poo,1
 en_US,ass/asses,literally buttocks but also used to mean a jerk (also a dated term for a donkey),1
 en_US,asshole/assholes,idiot,2
@@ -307,7 +307,7 @@ fi,runkkari,vulgar word for idiot,3
 fi,ryssä,vulgar name for russian people,3
 fi,saatana,the devil,2
 fi,tissi,breast,1
-fi,transu,vulgar word for transsexual person,3
+fi,transu,vulgar word for transgender person,3
 fi,vittu,vulgar word for vagina,3
 fr,abruti,idiot,1
 fr,baiser,vulgar word for sex,3
@@ -605,6 +605,6 @@ sv,svartskalle,vulgar word for dark-skinned person,3
 sv,svenne/svennebanan,derogatory word for ethnic Swedes,2
 sv,tattare,romani,3
 sv,tönt,social misfit; dork,1
-sv,transa,derogatory word for transsexual,3
+sv,transa,derogatory word for transgender person,3
 sv,tutte,breast,1
 sv,zigenare,romani,3


### PR DESCRIPTION
Transgender is the more widely-accepted umbrella term, while transsexual can be considered dated or at least a subset of the former.